### PR TITLE
WIP: ENH: add black box to allow adaptive model selection on any class

### DIFF
--- a/dask_ml/model_selection/__init__.py
+++ b/dask_ml/model_selection/__init__.py
@@ -5,9 +5,11 @@ on the underlying estimators being used.
 """
 from ._search import GridSearchCV, RandomizedSearchCV, compute_n_splits, check_cv
 from ._split import ShuffleSplit, KFold, train_test_split
+from ._black_box import BlackBox
 
 
 __all__ = [
+    "BlackBox",
     "GridSearchCV",
     "RandomizedSearchCV",
     "ShuffleSplit",

--- a/dask_ml/model_selection/_black_box.py
+++ b/dask_ml/model_selection/_black_box.py
@@ -1,0 +1,64 @@
+import numpy as np
+from sklearn.base import BaseEstimator, MetaEstimatorMixin
+
+
+class BlackBox(BaseEstimator, MetaEstimatorMixin):
+    """
+    Fit an estimator with a subset of the data passed.
+
+    This is most useful in cross validation searches because it treats the
+    estimator as a black box.
+
+    Parameters
+    ----------
+    est : BaseEstimator
+        The base estimator to fit with data
+
+    max_calls : int, optional
+        The maximum number of times this estimator wil be called.
+
+    """
+
+    def __init__(self, estimator, max_iter=1, **kwargs):
+        self.estimator = estimator
+        self.max_iter = max_iter
+        self.kwargs = kwargs
+        self._calls = 0
+
+    def _set_kwargs(self):
+        est_kwargs = {k[4:]: v for k, v in self.kwargs.items() if k[:4] == "est_"}
+        return self.estimator.set_params(**est_kwargs)
+
+    def fit(self, X, y):
+        self.estimator = self._set_kwargs()
+        self.estimator.fit(X, y)
+        return self
+
+    def partial_fit(self, X, y=None):
+        if self._calls == 0:
+            self.estimator = self._set_kwargs()
+        self._calls += 1
+        frac = self._calls / self.max_iter
+        n = X.shape[0]
+        num_data = int(n * frac)
+        num_data = np.clip(num_data, 2, n)
+        idx = np.random.permutation(n)[:num_data]
+        self.estimator.fit(X[idx], y[idx])
+        return self
+
+    def score(self, X, y=None):
+        return self.estimator.score(X, y)
+
+    def get_params(self, **kwargs):
+        est_kwargs = {
+            "est_" + k: v for k, v in self.estimator.get_params(**kwargs).items()
+        }
+        return {"estimator": self.estimator, **est_kwargs}
+
+    def set_params(self, **kwargs):
+        est_kwargs = {k[4:]: v for k, v in kwargs.items() if k[:4] == "est_"}
+        other_kwargs = {k: v for k, v in kwargs.items() if k[4:] not in est_kwargs}
+        self.estimator.set_params(**est_kwargs)
+        for k, v in other_kwargs.items():
+            setattr(self, k, v)
+        return self

--- a/tests/model_selection/test_black_box.py
+++ b/tests/model_selection/test_black_box.py
@@ -1,0 +1,37 @@
+from distributed.utils_test import gen_cluster
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+from sklearn.datasets import make_classification as sk_make_classification
+from sklearn.base import clone
+from dask_ml.model_selection import BlackBox, IncrementalSearchCV
+
+
+def test_black_box_basic():
+    params = {"C": np.logspace(-3, 1, num=400)}
+    est = LogisticRegression(solver="lbfgs")
+    wrapper = BlackBox(est, max_iter=2)
+    assert wrapper.max_iter == 2
+
+    X, y = sk_make_classification(n_samples=20, n_features=5)
+    wrapper.partial_fit(X, y)
+    wrapper.partial_fit(X, y)
+    assert wrapper._calls == 2
+
+
+@gen_cluster(client=True, timeout=5000)
+def test_black_box_w_search(c, s, a, b):
+    max_iter = 4
+    params = {"C": np.logspace(-3, 1, num=400)}
+    est = LogisticRegression(solver="lbfgs")
+    wrapper = BlackBox(est, max_iter=max_iter)
+    X, y = sk_make_classification(n_samples=50, n_features=5)
+
+    w2 = clone(wrapper)
+    assert type(w2) == type(wrapper)
+    assert type(w2.set_params(C=2 * np.pi)) == type(w2)
+
+    search = IncrementalSearchCV(wrapper, params, decay_rate=0, max_iter=max_iter)
+    yield search.fit(X, y)
+    assert search.best_estimator_._calls == max_iter
+    assert search.best_score_ > 0
+    assert type(search.best_estimator_) == type(wrapper)


### PR DESCRIPTION
**What does this PR implement?**
This allows for Hyperband to work with any estimator, not only those that implement `partial_fit`. It does this by fitting a (random) subset of the data passed to `partial_fit`.

This makes sense when computationally constrained, not memory constrained. I would expect this class to be used with Hyperband (or other adaptive searches) when computationally constrained, not memory constrained.

A good use-case for this is finding the hyper-parameters for embedding data into a low-dimensional space. This tends to be computationally expensive with moderate data and has many hyper-parameters (and they matter; see "[Using t-SNE effectively][1]").

**Related work**
This is based off the documentation re-organization in #221.

[1]:https://distill.pub/2016/misread-tsne/

**TODO**
- [ ] better documentation
- [ ] implement an example